### PR TITLE
Implement CLI subcommand to change data path

### DIFF
--- a/src/cli/tasks/_config.js
+++ b/src/cli/tasks/_config.js
@@ -62,10 +62,8 @@ class RvmCliConfig {
         if(path) {
             config.rvm_data_dir = File.expandPath(path);
             RvmCliTools.writeRvmConfig(config);
-            self.printDataPath();
-        } else {
-            self.printDataPath();
         }
+        self.printDataPath();
     }
 
     static runProxy(hostname) {

--- a/src/cli/tasks/_config.js
+++ b/src/cli/tasks/_config.js
@@ -16,6 +16,8 @@ class RvmCliConfig {
             self.runDefault();
         } else if(["p", "proxy"].includes(command)) {
             self.runProxy();
+        } else if(["da", "data"].includes(command)) {
+            self.runDataPath();
         } else {
             self.printConfig();
         }

--- a/src/cli/tasks/_config.js
+++ b/src/cli/tasks/_config.js
@@ -47,6 +47,24 @@ class RvmCliConfig {
             console.log(`There is no default ruby version set. To set, run ${Chalk.green('rvm default <version>')}`);
         }
     }
+    
+    static printDataPath() {
+        const data_path = RvmCliTools.getRvmDataDir();
+        console.log(`RVM data directory at ${Chalk.green(data_path)}`);
+    }
+
+    static runDataPath() {
+        const self = RvmCliConfig;
+        let config = RvmCliTools.config();
+        const path = process.argv[4];
+        if(path) {
+            config.rvm_data_dir = File.expandPath(path);
+            RvmCliTools.writeRvmConfig(config);
+            self.printDataPath();
+        } else {
+            self.printDataPath();
+        }
+    }
 
     static runProxy(hostname) {
         const self = RvmCliConfig;

--- a/src/cli/tasks/_help.js
+++ b/src/cli/tasks/_help.js
@@ -39,6 +39,8 @@ RvmCliHelp.SECTIONS.help = [
             {name: 'config', alias: 'cfg', summary: 'Print current RVM config'},
             {name: 'config default', alias: 'cfg d', summary: 'Print default version'},
             {name: 'config default <version>', alias: 'cfg d <version>', summary: 'Set default version'},
+            {name: 'config data', alias: 'cfg da', summary: 'Print RVM data directory'},
+            {name: 'config data <path>', alias: 'cfg da <path>', summary: 'Set RVM data directory'},
             {name: 'config proxy', alias: 'cfg p', summary: 'Get the configured proxy host.'},
             {name: 'config proxy <host>', alias: 'cfg p <host>', summary: 'Set the proxy server host. E.g. http://proxy:12345'},
             {name: 'config proxy delete', alias: 'cfg p delete', summary: 'Remove the proxy server host from the configuration.'},


### PR DESCRIPTION
This PR adds a new subcommand, `rvm config data [path]`/`rvm cfg da [path]`, to view or update the data path for RVM-Windows. This could previously be achieved by editing the config file directly.

The reason for this change is to make it simpler to install Ruby versions to an alternate location, such as an alternate drive. Having to find and edit the config file isn't difficult, per se, but it is higher effort than having a CLI alternative. (Anecdotally, not having this option has prevented me from adopting RVM-Windows at least one time in the past.)

Thoughts and feedback welcome.